### PR TITLE
Fix data logging parameter for Data_GUI

### DIFF
--- a/Golf Swing Model/Scripts/Simulation_Dataset_GUI/Data_GUI.m
+++ b/Golf Swing Model/Scripts/Simulation_Dataset_GUI/Data_GUI.m
@@ -2121,7 +2121,9 @@ function simIn = setModelParameters(simIn, config)
         
         % Additional logging parameters
         simIn = simIn.setModelParameter('LoggingToFile', 'off');
-        simIn = simIn.setModelParameter('LoggingToWorkspace', 'on');
+        % Use ReturnWorkspaceOutputs to return simulation results
+        % directly to the MATLAB workspace.
+        simIn = simIn.setModelParameter('ReturnWorkspaceOutputs', 'on');
         
         % Ensure all signals are logged
         simIn = simIn.setModelParameter('SignalLogging', 'on');


### PR DESCRIPTION
## Summary
- ensure Data_GUI configures return of outputs to workspace using `ReturnWorkspaceOutputs`

## Testing
- `grep -n LoggingToWorkspace -R .`

------
https://chatgpt.com/codex/tasks/task_e_68884b49226c8320b9693e5694acad06