### PR TITLE
refactor: parallel ZTCF generation

### DIFF
--- a/2D GUI/data_processing/generate_ztcf_data.m
+++ b/2D GUI/data_processing/generate_ztcf_data.m
@@ -1,77 +1,70 @@
-function ZTCF = generate_ztcf_data(config, mdlWks, BaseData)
+function ZTCF = generate_ztcf_data(config, ~, BaseData)
 % GENERATE_ZTCF_DATA - Generate ZTCF (Zero Torque Counterfactual) data
 %
 % Inputs:
 %   config - Configuration structure from model_config()
-%   mdlWks - Model workspace handle from initialize_model()
+%   mdlWks - (unused) Model workspace handle kept for API compatibility
 %   BaseData - Base data table from generate_base_data()
 %
 % Returns:
 %   ZTCF - Table containing the ZTCF data
 %
 % This function:
-%   1. Loops through time points to generate ZTCF data
-%   2. Creates a table with ZTCF data for each time point
-%   3. Returns the compiled ZTCF data
+%   1. Runs simulations in parallel using parsim
+%   2. Accumulates results in a struct array
+%   3. Converts the results to a table once at the end
 
-    % Initialize ZTCF table with same structure as BaseData
-    ZTCFTable = BaseData;
-    ZTCFTable(:,:) = []; % Clear all data but keep structure
-    
-    % Change to scripts directory
-    cd(config.scripts_path);
-    
-    fprintf('🔄 Generating ZTCF data...\n');
-    
-    % Loop through time points
-    for i = config.ztcf_start_time:config.ztcf_end_time
-        
-        % Scale counter to match desired times
-        j = i / config.ztcf_time_scale;
-        
-        % Display progress
-        progress = i / config.ztcf_end_time * 100;
-        fprintf('   Progress: %.1f%% (Time: %.3f s)\n', progress, j);
-        
-        % Set killswitch time in model workspace
-        assignin(mdlWks, 'KillswitchStepTime', Simulink.Parameter(j));
-        
-        % Run simulation
-        out = sim(config.model_name);
-        SCRIPT_TableGeneration;
-        ZTCFData = Data;
-        
+    % Determine time points for ZTCF simulations
+    timePoints = config.ztcf_start_time:config.ztcf_end_time;
+    numPoints = numel(timePoints);
+
+    % Preallocate results structure based on BaseData
+    templateStruct = table2struct(BaseData(1,:));
+    ztcfResults(numPoints,1) = templateStruct;
+
+    % Prepare simulation inputs for parsim
+    simIn(numPoints,1) = Simulink.SimulationInput(config.model_name);
+    for idx = 1:numPoints
+        j = timePoints(idx) / config.ztcf_time_scale;
+        simIn(idx) = simIn(idx).setVariable('KillswitchStepTime', Simulink.Parameter(j));
+        simIn(idx) = simIn(idx).setPostSimFcn(@(in,out)postSimProcess(out, config.scripts_path));
+    end
+
+    fprintf('🔄 Generating ZTCF data with %d simulations...\n', numPoints);
+
+    % Run all simulations in parallel
+    simOut = parsim(simIn, 'ShowProgress', 'on');
+
+    % Process simulation results
+    for idx = 1:numPoints
+        ZTCFData = simOut(idx).Data;
+
         % Find the row where KillswitchState first becomes zero
         row = find(ZTCFData.KillswitchState == 0, 1);
-        
+
         if isempty(row)
-            warning('No killswitch state change found at time %.3f', j);
+            warning('No killswitch state change found at time %.3f', ...
+                timePoints(idx) / config.ztcf_time_scale);
             continue;
         end
-        
-        % Create ZTCF row
-        ZTCF = ZTCFData;
-        ZTCF(1,:) = ZTCFData(row,:);
-        
-        % Remove all other rows
-        H = height(ZTCF) - 1;
-        for k = 1:H
-            DelRow = H + 2 - k;
-            ZTCF(DelRow,:) = [];
-        end
-        
-        % Add to ZTCF table
-        ZTCFTable = [ZTCFTable; ZTCF];
-        
+
+        ztcfResults(idx) = table2struct(ZTCFData(row,:));
     end
-    
-    % Reset killswitch time
-    assignin(mdlWks, 'KillswitchStepTime', Simulink.Parameter(config.killswitch_time));
-    
-    % Clean up and return
-    ZTCF = ZTCFTable;
-    
+
+    % Convert accumulated results to table
+    ZTCF = struct2table(ztcfResults);
+
     fprintf('✅ ZTCF data generated successfully\n');
     fprintf('   ZTCF data points: %d\n', height(ZTCF));
-    
+
+end
+
+function simOut = postSimProcess(simOut, scriptsPath)
+%POSTSIMPROCESS Generate Data table after each simulation
+    prevDir = pwd;
+    cd(scriptsPath);
+    out = simOut; %#ok<NASGU>
+    SCRIPT_TableGeneration;
+    simOut.Data = Data; %#ok<NODEF>
+    cd(prevDir);
 end


### PR DESCRIPTION
## Summary
- Run ZTCF simulations in parallel using `parsim`
- Preallocate results and convert once to a table to avoid dynamic concatenation

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68951e4d2d9c8320864f5f30f63ec093