### PR TITLE
refactor: restore working directory

### DIFF
--- a/3DModel/SCRIPT_LoadImpact.m
+++ b/3DModel/SCRIPT_LoadImpact.m
@@ -2,18 +2,20 @@
 % Read from model workspace the value in the starting position / velocity
 % from the impact optimized model
 
+origDir = pwd;
+cleanup = onCleanup(@() cd(origDir));
+
 % First load up the model and set up a model workspace to write the
 % variables to with the mdlWks function.
-cd(matlabdrive);
-cd '3DModel'
-GolfSwing3D_KineticallyDriven;
-mdlWks=get_param('GolfSwing3D_KineticallyDriven','ModelWorkspace');
+modelDir = fullfile(matlabdrive, '3DModel');
+load_system(fullfile(modelDir, 'GolfSwing3D_KineticallyDriven.slx'));
+mdlWks = get_param('GolfSwing3D_KineticallyDriven', 'ModelWorkspace');
 
 
 % Read from source file into the workspace.
 % load("3DModelInputs.mat")
 % load("3DModelInputs_TopofBackswing.mat")
-load("3DModelInputs_Impact.mat")
+load(fullfile(modelDir, '3DModelInputs_Impact.mat'))
 
 % Copy only the kinematics from the workspace to the model workspace.
 
@@ -128,11 +130,13 @@ assignin(mdlWks,"RWStartVelocityX",Simulink.Parameter(RWStartVelocityX.Value))
 assignin(mdlWks,"RWStartVelocityY",Simulink.Parameter(RWStartVelocityY.Value))
 
 % Save Model Workspace
-save(mdlWks,'3DModelInputs.mat')
+save(mdlWks, fullfile(modelDir, '3DModelInputs.mat'))
 
 % Clear Workspace
 clear
-mdlWks=get_param('GolfSwing3D_KineticallyDriven','ModelWorkspace');
+mdlWks = get_param('GolfSwing3D_KineticallyDriven', 'ModelWorkspace');
 
 % Run Model
-out=sim("GolfSwing3D_KineticallyDriven.slx");
+modelDir = fullfile(matlabdrive, '3DModel');
+modelPath = fullfile(modelDir, 'GolfSwing3D_KineticallyDriven.slx');
+out = sim(modelPath);

--- a/3DModel/SCRIPT_RunKinematicModelFromAtoB.m
+++ b/3DModel/SCRIPT_RunKinematicModelFromAtoB.m
@@ -1,15 +1,13 @@
-cd(matlabdrive);
-% This script loads impact state targets into the model workspace from the
-% impact model and then loads the model into a top of backswing position.
-% Then the model is kinematically driven between the two states.
+origDir = pwd;
+cleanup = onCleanup(@() cd(origDir));
 
-cd 3DModel;
-SCRIPT_LoadImpactStateTargets;
-SCRIPT_LoadTopofBackswing
+% Load impact state targets and top of backswing data without changing directories
+modelDir = fullfile(matlabdrive, '3DModel');
+run(fullfile(modelDir, 'SCRIPT_LoadImpactStateTargets.m'));
+run(fullfile(modelDir, 'SCRIPT_LoadTopofBackswing.m'));
 
 % Run kinematic model with the target values
-cd(matlabdrive);
-cd 3DModel;
-assignin(mdlWks,'StopTime',Simulink.Parameter(0.2));
-GolfSwing3D_KinematicallyDriven;
-out=sim("GolfSwing3D_KinematicallyDriven.slx");
+assignin(mdlWks, 'StopTime', Simulink.Parameter(0.2));
+run(fullfile(modelDir, 'GolfSwing3D_KinematicallyDriven.m'));
+modelPath = fullfile(modelDir, 'GolfSwing3D_KinematicallyDriven.slx');
+out = sim(modelPath);


### PR DESCRIPTION
## Summary
- avoid directory switches in 3D model scripts
- call model scripts with absolute paths and restore working directory

## Testing
- `matlab -batch "disp('test run')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68951e475dcc8320bbf34b450558f320